### PR TITLE
Update Python, include http server code in repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To test a track, follow the following steps:
 
     - For example, `cd tracks/conjur.org/secure-ci-cd-pipelines`
 
-3. Run `instruqt track validate` to validate the format of the track, or `instruqt track test` to run a
+3. Run `instruqt track validate` to validate the format of the track, or `instruqt track test --skip-fail-check` to run a
     full test of the track with it's lifecycle scripts.
 
 ## Releases

--- a/env/conjur-jenkins/http-auth-server/Dockerfile
+++ b/env/conjur-jenkins/http-auth-server/Dockerfile
@@ -1,6 +1,5 @@
-FROM python:2.7 
+FROM python:3.9.16-slim-bullseye
+COPY ./http_server_auth.py /http_server_auth.py
 
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir git+https://github.com/tianhuil/SimpleHTTPAuthServer.git@master 
-
-CMD ["python","-m","SimpleHTTPAuthServer","80","theServerAccount:NotSoSecureSecret"]
+WORKDIR /
+CMD ["python","-m","http_server_auth","-u","theServerAccount","-p","NotSoSecureSecret","80"]

--- a/env/conjur-jenkins/http-auth-server/http_server_auth.py
+++ b/env/conjur-jenkins/http-auth-server/http_server_auth.py
@@ -1,0 +1,80 @@
+# Credit to https://gist.github.com/mauler/593caee043f5fe4623732b4db5145a82
+
+# Extended python -m http.serve with --username and --password parameters for
+# basic auth, based on https://gist.github.com/fxsjy/5465353
+
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, test
+import base64
+import os
+
+
+class AuthHTTPRequestHandler(SimpleHTTPRequestHandler):
+    """ Main class to present webpages and authentication. """
+
+    def __init__(self, *args, **kwargs):
+        username = kwargs.pop("username")
+        password = kwargs.pop("password")
+        self._auth = base64.b64encode(f"{username}:{password}".encode()).decode()
+        super().__init__(*args, **kwargs)
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+
+    def do_AUTHHEAD(self):
+        self.send_response(401)
+        self.send_header("WWW-Authenticate", 'Basic realm="Test"')
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+
+    def do_GET(self):
+        """ Present frontpage with user authentication. """
+        if self.headers.get("Authorization") == None:
+            self.do_AUTHHEAD()
+            self.wfile.write(b"no auth header received")
+        elif self.headers.get("Authorization") == "Basic " + self._auth:
+            SimpleHTTPRequestHandler.do_GET(self)
+        else:
+            self.do_AUTHHEAD()
+            self.wfile.write(self.headers.get("Authorization").encode())
+            self.wfile.write(b"not authenticated")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cgi", action="store_true", help="Run as CGI Server")
+    parser.add_argument(
+        "--bind",
+        "-b",
+        metavar="ADDRESS",
+        default=None,
+        help="Specify alternate bind address " "[default: all interfaces]",
+    )
+    parser.add_argument(
+        "--directory",
+        "-d",
+        default=os.getcwd(),
+        help="Specify alternative directory " "[default:current directory]",
+    )
+    parser.add_argument(
+        "port",
+        action="store",
+        default=8000,
+        type=int,
+        nargs="?",
+        help="Specify alternate port [default: 8000]",
+    )
+    parser.add_argument("--username", "-u", metavar="USERNAME")
+    parser.add_argument("--password", "-p", metavar="PASSWORD")
+    args = parser.parse_args()
+    handler_class = partial(
+        AuthHTTPRequestHandler,
+        username=args.username,
+        password=args.password,
+        directory=args.directory,
+    )
+    test(HandlerClass=handler_class, port=args.port, bind=args.bind)

--- a/tracks/conjur.org/secure-ci-cd-pipelines/09-conjur-conn/assignment.md
+++ b/tracks/conjur.org/secure-ci-cd-pipelines/09-conjur-conn/assignment.md
@@ -53,7 +53,7 @@ host/jenkins-frontend/frontend-01
   cat frontend.out
   ```
 
-3. Click OK.
+3. Click Create.
 
 You can also decide whether to set up global or folder-level access to Conjur, or a combination of both.
 

--- a/tracks/conjur.org/secure-ci-cd-pipelines/track.yml
+++ b/tracks/conjur.org/secure-ci-cd-pipelines/track.yml
@@ -51,5 +51,4 @@ developers:
 - joe@joe-garcia.com
 - sean@instruqt.com
 - shlomo.heigh@cyberark.com
-maintenance: true
-checksum: "903670769312054464"
+checksum: "13582046619389986514"


### PR DESCRIPTION
### Desired Outcome

The CI/CD (Jenkins) [track](https://play.instruqt.com/cyberark/tracks/secure-ci-cd-pipelines-v2) uses a small HTTP server that implements HTTP Basic Authentication. This was using Python 2.x and pulling in the code from GitHub. The goal was to upgrade to Python 3.x and decrease the size of the container by including the very simple server code in the repository instead of pulling it from GitHub.

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
